### PR TITLE
#153 Require moment dependency

### DIFF
--- a/dist/mdPickers.js
+++ b/dist/mdPickers.js
@@ -1,6 +1,7 @@
 (function() {
 "use strict";
 /* global moment, angular */
+var moment = require("moment");
 
 var module = angular.module("mdPickers", [
 	"ngMaterial",

--- a/src/mdPickers.js
+++ b/src/mdPickers.js
@@ -1,4 +1,5 @@
 /* global moment, angular */
+var moment = require("moment");
 
 var module = angular.module("mdPickers", [
 	"ngMaterial",


### PR DESCRIPTION
 This fixes bug with unknown variable `moment` when mdPickers is used
 under webpack