### PR TITLE
Support Angularjs 1.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.6.0",
+    "angular": "~1.5.0 || ~1.6.0",
     "angular-material": "^1.0.4",
     "moment": "~2.11.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/dpoetzsch/md-pickers",
   "dependencies": {
-    "angular": "^1.5.0",
+    "angular": "~1.5.0 || ~1.6.0",
     "angular-material": "^1.0.4",
     "moment": "~2.11.1"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/dpoetzsch/md-pickers",
   "dependencies": {
-    "angular": "~1.6.0",
+    "angular": "^1.5.0",
     "angular-material": "^1.0.4",
     "moment": "~2.11.1"
   },


### PR DESCRIPTION
Hi, thanks for this great package.

Before adding `"angular": "~1.6.0"`, this package worked perfectly with Angularjs 1.5, adding it just force npm to install it in node_modules. So we have in our project angularjs 1.5 and 1.6 (installed by md-pickers but the 1.6 is not used), the version here should be the lowest compatible, so 1.5 for sure, maybe lower.

Note: adding `"angular": "~1.6.0"` does not enable Angularjs 1.6 support, it would mean the library only support >=1.60 <1.7.0.